### PR TITLE
ARXIVNG-2064

### DIFF
--- a/compiler/compiler.py
+++ b/compiler/compiler.py
@@ -220,8 +220,8 @@ def update_sent_state(sender=None, headers=None, body=None, **kwargs):
 
 @celery_app.task
 def do_compile(source_id: str, checksum: str,
-               stamp_label: str,
-               stamp_link: str,
+               stamp_label: Optional[str],
+               stamp_link: Optional[str],
                output_format: str = 'pdf',
                preferred_compiler: Optional[str] = None,
                token: Optional[str] = None,
@@ -351,7 +351,7 @@ def _store_compilation_result(status: Task, out_path: Optional[str],
 # TODO: rename []_dvips_flag parameters when we figure out what they mean.
 # TODO: can we get rid of any of these?
 def _run(source: SourcePackage,
-         stamp_label: str, stamp_link: str,
+         stamp_label: Optional[str], stamp_link: Optional[str],
          output_format: Format = Format.PDF,
          add_stamp: bool = True, timeout: int = 600,
          add_psmapfile: bool = False, P_dvips_flag: bool = False,
@@ -375,6 +375,8 @@ def _run(source: SourcePackage,
         (True, '-S /autotex'),
         (True, f'-p {source.source_id}'),
         (True, f'-f {output_format.value}'),  # Doesn't do what it seems.
+        (stamp_label is not None, f'-l "{stamp_label}"'),
+        (stamp_link is not None, f'-L "{stamp_link}"'),
         (True, f'-T {timeout}'),
         (True, f'-t {dvips_layout}'),
         (True, '-q'),
@@ -385,10 +387,6 @@ def _run(source: SourcePackage,
         (id_for_decryption is not None, f'-d {id_for_decryption}'),
         (tex_tree_timestamp is not None, f'-U {tex_tree_timestamp}')
     ]
-    if stamp_label:
-        options.append((True, f'-l "{stamp_label}"'))
-    if stamp_link:
-        options.append((True, f'-L "{stamp_link}"'))
 
     args = [arg for opt, arg in options if opt]
 

--- a/compiler/controllers.py
+++ b/compiler/controllers.py
@@ -81,6 +81,12 @@ def compile(request_data: MultiDict, token: str, session: Session,
 
     # We don't want to compile the same source package twice.
     force = request_data.get('force', False)
+
+    # Support label and link for PS/PDF Stamping
+    # Test
+    stamp_label = request_data.get('stamp_label', None) # or is '' better?
+    stamp_link = request_data.get('stamp_link', None)
+
     logger.debug('%s: request compilation with %s', __name__, request_data)
     if not force:
         info = _status_from_store(source_id, checksum, output_format)
@@ -91,7 +97,9 @@ def compile(request_data: MultiDict, token: str, session: Session,
             return _redirect_to_status(source_id, checksum, output_format)
 
     try:
-        compiler.start_compilation(source_id, checksum, output_format,
+        compiler.start_compilation(source_id, checksum,
+                                   stamp_label, stamp_link,
+                                   output_format,
                                    token=token, owner=session.user.user_id)
     except compiler.TaskCreationFailed as e:
         logger.error('Failed to start compilation: %s', e)

--- a/compiler/controllers.py
+++ b/compiler/controllers.py
@@ -84,7 +84,7 @@ def compile(request_data: MultiDict, token: str, session: Session,
 
     # Support label and link for PS/PDF Stamping
     # Test
-    stamp_label = request_data.get('stamp_label', None) # or is '' better?
+    stamp_label = request_data.get('stamp_label', None)
     stamp_link = request_data.get('stamp_link', None)
 
     logger.debug('%s: request compilation with %s', __name__, request_data)

--- a/compiler/tests/test_compiler.py
+++ b/compiler/tests/test_compiler.py
@@ -444,10 +444,11 @@ class TestRun(TestCase):
         }
         mock_dock.return_value = (0, 'wooooo', '')
         pkg = domain.SourcePackage('1234', source_path, 'asdf1234=')
-        out_path, log_path = compiler._run(pkg)
+        out_path, log_path = compiler._run(pkg, "arXiv:1234",
+                                           "http://arxiv.org/abs/1234")
         self.assertTrue(out_path.endswith('/tex_cache/foo.pdf'))
         self.assertTrue(log_path.endswith('/tex_logs/autotex.log'))
-        shutil.rmtree(source_dir)   # Cleanup.
+        shutil.rmtree(source_dir)  # Cleanup.
 
     @mock.patch(f'{compiler.__name__}.run_docker')
     @mock.patch(f'{compiler.__name__}.current_app')
@@ -470,7 +471,8 @@ class TestRun(TestCase):
         }
         mock_dock.return_value = (0, 'wooooo', '')
         pkg = domain.SourcePackage('1234', source_path, 'asdf1234=')
-        out_path, log_path = compiler._run(pkg)
+        out_path, log_path = compiler._run(pkg, "arXiv:1234",
+                                           "http://arxiv.org/abs/1234")
         self.assertIsNone(out_path)
         self.assertTrue(log_path.endswith('/tex_logs/autotex.log'))
         shutil.rmtree(source_dir)   # Cleanup.

--- a/compiler/tests/test_compiler.py
+++ b/compiler/tests/test_compiler.py
@@ -31,7 +31,8 @@ class TestStartCompilation(TestCase):
     @mock.patch(f'{compiler.__name__}.store', mock.MagicMock())
     def test_start_compilation_ok(self):
         """Compilation starts succesfully."""
-        task_id = compiler.start_compilation('1234', 'asdf1234=',
+        task_id = compiler.start_compilation('1234', 'asdf1234=', 'arXiv:1234',
+                                             'http://arxiv.org/abs/1234',
                                              output_format=domain.Format.PDF,
                                              token='footoken')
         self.assertEqual(task_id, "1234/asdf1234=/pdf", "Returns task ID")
@@ -46,6 +47,7 @@ class TestStartCompilation(TestCase):
         mock_do_compile.apply_async.side_effect = raise_runtimeerror
         with self.assertRaises(compiler.TaskCreationFailed):
             compiler.start_compilation('1234', 'asdf1234=',
+                                       'arXiv:1234', 'http://arxiv.org/abs/1234',
                                        output_format=domain.Format.PDF,
                                        token='footoken')
 
@@ -140,7 +142,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',
@@ -175,7 +179,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',
@@ -211,7 +217,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',
@@ -247,7 +255,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',
@@ -283,7 +293,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',
@@ -319,7 +331,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',
@@ -350,7 +364,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',
@@ -386,7 +402,9 @@ class TestDoCompile(TestCase):
         })
         with app.app_context():
             self.assertDictEqual(
-                compiler.do_compile("1234", "asdf", "pdf", token="footoken"),
+                compiler.do_compile("1234", "asdf", "arXiv:1234",
+                                    "http://arxiv.org/abs/1234", "pdf",
+                                    token="footoken"),
                 {
                     'source_id': '1234',
                     'output_format': 'pdf',

--- a/schema/resources/requestCompilation.json
+++ b/schema/resources/requestCompilation.json
@@ -8,6 +8,14 @@
     "checksum": {"type": "string"},
     "format": {"type": "string"},
     "force": {"type": "boolean"},
-    "compiler": {"type": "string"}
+    "compiler": {"type": "string"},
+    "stamp_label": {
+      "description": "Label to use in PS/PDF stamp/watermark",
+      "type": "string"
+    },
+    "stamp_link": {
+      "description": "Link to associate with label in PS/PDF stamp/watermark",
+      "type": "string"
+    }
   }
 }


### PR DESCRIPTION
This pull request adds stamp_label and stamp_link arguments that allow compiler client to specify PDF stamp parameters.

This is a small set of changes. 

I tested this by setting stamp_label and stamp_link in the controller as if they were set by an incoming. request. PDF was created with the specified label/link.

I need to look at ways to add tests that stamp PDF and inspect generated PDF to determine label/link are correct.

