### PR TITLE
ARXIVNG-2609 request for a product or log for which task in progress results in redirect to status

### DIFF
--- a/compiler/controllers.py
+++ b/compiler/controllers.py
@@ -214,6 +214,9 @@ def get_product(source_id: str, checksum: str, output_format: str,
     if not is_authorized(task_state):
         raise Forbidden('Access denied')
 
+    if not task_state.is_completed:
+        return _redirect_to_status(source_id, checksum, product_format)
+
     store = Store.current_session()
     try:
         product = store.retrieve(source_id, checksum, product_format)
@@ -263,6 +266,8 @@ def get_log(source_id: str, checksum: str, output_format: str,
         raise NotFound('No such task') from e
     if not is_authorized(task_state):
         raise Forbidden('Access denied')
+    if not task_state.is_completed:
+        return _redirect_to_status(source_id, checksum, product_format)
 
     store = Store.current_session()
     try:


### PR DESCRIPTION
Fixes #22 

Went for the simplest solution I could think of: if a client requests a product or log for a task that is in progress, they are redirected to the task status endpoint. This will occur in both the case that the compilation is occurring for the first time, as well as the case that the source is being recompiled (e.g. via a "force"). The effective result for the latter case is that a client cannot retrieve a stale/invalid product or log.