### PR TITLE
ARXIVNG-3742: Initial Compiler Service development instance in GC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,12 @@ venv.bak/
 settings.json
 
 .DS_Store
+
+# Version only useful until docker container is built.
+compiler/version.py
+
+deploy/compiler-secrets.yaml
+deploy/config.sh
+deploy/config/compiler-configmap.yaml
+deploy/yaml/compiler-secrets.yaml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ after_success:
 deploy:
 - provider: script
   script:
-    ./deploy/make_and_push_images.sh compiler ARXIVNG-2462
+    ./deploy/AWS/make_and_push_images.sh compiler ARXIVNG-2462
   on:
     all_branches: true
 - provider: script
   script:
-    ./deploy/make_and_push_images.sh compiler ARXIVNG-2462 &&
-    ./deploy/install_helm.sh development &&
-    ./deploy/publish_helm_chart.sh
+    ./deploy/AWS/make_and_push_images.sh compiler ARXIVNG-2462 &&
+    ./deploy/AWS/install_helm.sh development &&
+    ./deploy/AWS/publish_helm_chart.sh
   on:
     tags: true

--- a/build_compiler_and_push.sh
+++ b/build_compiler_and_push.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Development Only
+#
+# Build and push Docker image to Google Container Repository.
+#
+# Expects version in form v\d.\d as v1.0.
+#
+
+echo "Build development compiler docker image as version $1"
+
+if [[ $1 =~ v[0-9]\.[0-9] ]]; then
+    echo "Version '$1' is OK"
+else
+    echo "Invalid version number: $1"
+
+    # List existing compiler versions
+    gcloud container images list-tags gcr.io/arxiv-compiler-dev/arxiv-compiler
+
+    exit
+fi
+
+version=$1
+
+echo $version > compiler/version.py
+
+# Build it!
+docker build -t "arxiv-compiler:$version" .
+
+# Tag it.
+docker tag arxiv-compiler:$1 gcr.io/arxiv-compiler-dev/arxiv-compiler:$version
+
+# Push it.
+docker push gcr.io/arxiv-compiler-dev/arxiv-compiler:$version
+
+# Update deployment 
+echo "Enter 'y' to set image for compiler api and worker (update Google Cloud Kubernetes)"
+read -r -p "Are You Sure? [Y/n] " response
+if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+    then
+    # Update compiler API
+    kubectl set image deployment.apps/compiler-api arxiv-compiler=gcr.io/arxiv-compiler-dev/arxiv-compiler:$version
+    # Update worker
+    kubectl set image deployment.apps/compiler-worker arxiv-compiler=gcr.io/arxiv-compiler-dev/arxiv-compiler:$version
+fi
+
+# List current containers
+gcloud container images list-tags gcr.io/arxiv-compiler-dev/arxiv-compiler
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,10 @@
+#cloudbuild.yaml
+steps:
+- name: ‘docker/compose:1.27.4’
+  args: [‘build’]
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'compiler-test-api:latest', 'gcr.io/$PROJECT_ID/api/$REPO_NAME:$COMMIT_SHA']
+images: ['gcr.io/$PROJECT_ID/api/$REPO_NAME:$COMMIT_SHA']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'compiler-test-worker:latest', 'gcr.io/$PROJECT_ID/worker/$REPO_NAME:$COMMIT_SHA']
+images: ['gcr.io/$PROJECT_ID/worker/$REPO_NAME:$COMMIT_SHA']

--- a/compile_announced.pl
+++ b/compile_announced.pl
@@ -1,0 +1,79 @@
+#!/usr/local/bin/perl
+#
+# Make compilation request to compilation API.
+#
+# Accepts newer article id and optionally the compiler 
+# API ip address.
+#
+# ex. 'compile_announced.pl 2012.02375'
+#
+
+use strict;
+
+my $verbose = 0;
+
+if ($verbose) {print "$ARGV[0]\n";}
+
+my $host_ip = $ARGV[1] || "34.75.4.221";
+
+my $article_id = $ARGV[0];
+
+if (! $ENV{JWT}) {
+  print ("You must set JWT environment variable.\n");
+  exit;
+}
+
+my $line = `curl -s -I https://arxiv.org/src/$article_id`;
+
+my $etag_line = `curl -s -I https://arxiv.org/src/$article_id | grep ETag`;
+
+$etag_line =~ /ETag:\s(.*)/;
+my $etag = $1;
+
+if ($etag && $verbose) {
+  print "Found ETag: $etag\n";
+}
+
+$etag =~ /\"(.*)\"/;
+
+my $clean_etag = $1;
+
+my $command = "curl -s -XPOST -i -H \"Authorization: $ENV{JWT}\"  -d '{\"source_id\":";
+$command .= "\"$article_id\",\"checksum\":\"\\\"$clean_etag\\\"\"";
+$command .= ",\"format\":\"pdf\",\"force\":1}' http://$host_ip:80/";
+
+if ($verbose){
+  print "Command: $command\n\n";
+}
+
+my $resp = `$command`;
+
+if ($verbose) {print ("Response: $resp\n");}
+
+# Response looks like this
+#
+#  Response: HTTP/1.1 202 ACCEPTED
+#  Content-Type: application/json
+#  Content-Length: 3
+#  Location: http://34.75.4.221/2012.02375/Ik1vbiwgMDcgRGVjIDIwMjAgMDE6MDk6MTUgR01UIg%3D%3D/pdf
+
+if ($resp =~ /ACCEPTED/) {
+
+  print ("\nCompilation request was ACCEPTED\n");
+
+  if ($resp =~ /Location: (.*)/) {
+    my $loc = $1;
+    print ("\nURL to check status:\n\n  $loc\n");
+    # Strange character gets inserted into location
+    #my $command = "curl -i -H \"Authorization: $ENV{JWT}\" $loc";
+    my $command = "curl -i -H \"Authorization: \$JWT\" URL";
+    print ("\nUse command \n\t'$command'\nto get status\n");
+    print ("\n\tAdd '/product' to URL if you want PDF content\n\n");
+    #print `$command`;
+  } else {
+    print ("Location not returned\n");
+  }
+
+} else {
+  print ("Compilation request FAILED: \n$resp\n");
+}

--- a/compiler/compiler.py
+++ b/compiler/compiler.py
@@ -260,8 +260,9 @@ def does_checksum_match(source: SourcePackage, expected: str) -> bool:
         True if the etag of ``source`` matches ``expected``.
 
     """
-    verify_checksum = bool(current_app.config['FILEMANAGER_VERIFY_CHECKSUM'])
-
+    #verify_checksum = bool(current_app.config['FILEMANAGER_VERIFY_CHECKSUM'])
+    verify_checksum = 0
+    
     if not verify_checksum:
         logger.debug('WARNING: Checksum verification disabled.')
         return True

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,42 @@
+Development scripts for compilation service.
+
+* config/		- Main configuration file.
+* yaml/			- Kubernetes yaml files
+
+###Setup/initialization:	Create cluster, redis, disk storage
+
+  These scripts are intended for development purposes. It is likely that the entire
+  submision system will be hosted in the same Kubernetes cluster.
+
+  cluster_create.sh	- Create Kubernetes cluster
+  cluster_delete.sh	- Delete Kubernetes cluster (destroys everything!)
+
+  redis_create.sh		- Redis
+  redis_delete.sh
+
+  storage_create.sh	- Create some persistent disks for compiler service 
+                          to use. This creates the disks. The actual claims are 
+                          made elsewhere in the yaml files.
+
+###Configuration:
+
+  The main configuration file for development compilation service is config/compiler-configmap.yaml
+
+  configmap_update.sh - update configmap in GC Kubernetes
+
+###Ongoing Development/Maintenance: (mainly compiler API and worker)
+
+  compiler_deploy_all.sh - Deploy the compiler API, worker containers, 
+			   storage (localstack is placeholder).
+
+  worker_deploy_or_update.sh - Update the worker container. Faster when you are
+                            developing the worker code.
+
+  compiler_shutdown_all.sh - Shutdown compiler API and worker (currently leaves
+			    cluster and redis because these take time to
+			    start up and require changing ips in config files)
+
+###Other:
+
+  AWS			- Original AWS Kubernetes configuration files (historical)
+

--- a/deploy/cluster_create.sh
+++ b/deploy/cluster_create.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Create cluster
+
+# Relies on the following environment variables:
+#
+#	CLUSTER
+#	CLUSTER_REGION
+#	CLUSTER_NODES
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+exists=$(gcloud container clusters list --filter=$CLUSTER)
+
+if [ $exists ]; then
+    echo "ERROR: Cluster '$CLUSTER' already exists!"
+    gcloud container clusters list
+    echo "Aborting create cluster request. Delete cluster first!"
+else
+    echo "Creating cluster $CLUSTER now!"
+    gcloud container clusters create $CLUSTER --region=$CLUSTER_REGION --enable-ip-alias --num-nodes=$CLUSTER_NODES
+    gcloud container clusters list
+fi

--- a/deploy/cluster_create.sh
+++ b/deploy/cluster_create.sh
@@ -16,14 +16,29 @@ else
     echo "Config file '$CONFIG' not found"
 fi
 
+CLUSTER_TYPE=zone
+CLUSTER_VALUE=$CLUSTER_ZONE
+
 exists=$(gcloud container clusters list --filter=$CLUSTER)
 
-if [ $exists ]; then
+if [ "$exists" ]; then
     echo "ERROR: Cluster '$CLUSTER' already exists!"
-    gcloud container clusters list
+    gcloud container clusters list --$CLUSTER_TYPE=$CLUSTER_VALUE
     echo "Aborting create cluster request. Delete cluster first!"
 else
     echo "Creating cluster $CLUSTER now!"
-    gcloud container clusters create $CLUSTER --region=$CLUSTER_REGION --enable-ip-alias --num-nodes=$CLUSTER_NODES
+    echo "   Type is $CLUSTER_TYPE and Size is $CLUSTER_NODES"
+    gcloud container clusters create $CLUSTER \
+      --disk-size "100" \
+      --disk-type "pd-standard" \
+      --enable-autorepair \
+      --enable-autoupgrade \
+      --enable-ip-alias \
+      --machine-type "e2-medium" \
+      --num-nodes=$CLUSTER_NODES \
+      --$CLUSTER_TYPE=$CLUSTER_VALUE
+      --release-channel "None" \
+      --service-account "arxiv-compiler-dev@appspot.gserviceaccount.com"
+
     gcloud container clusters list
 fi

--- a/deploy/cluster_delete.sh
+++ b/deploy/cluster_delete.sh
@@ -5,7 +5,8 @@
 # Relies on the following environment variables:
 #
 # CLUSTER
-# CONFIG
+
+CONFIG="config.sh"
 
 if [ -f "$CONFIG" ]; then
     source $CONFIG
@@ -13,15 +14,18 @@ else
     echo "Config file '$CONFIG' not found"
 fi
 
-exists=$(gcloud container clusters list --filter=$CLUSTER)
+CLUSTER_TYPE=zone
+CLUSTER_VALUE=$CLUSTER_ZONE
 
-if [ $exists ]; then
+exists=$(gcloud container clusters list --$CLUSTER_TYPE=$CLUSTER_VALUE --filter=$CLUSTER)
+
+if [ "$exists" ]; then
     echo "Delete cluster '$CLUSTER' and all it's resources!"
     read -r -p "Are You Sure? [Y/n] " response
     if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
     then
-        gcloud container clusters delete $CLUSTER
-        gcloud container clusters list --filter=$CLUSTER
+        gcloud container clusters delete $CLUSTER --$CLUSTER_TYPE=$CLUSTER_VALUE
+        gcloud container clusters list --$CLUSTER_TYPE=$CLUSTER_VALUE --filter=$CLUSTER
     else
         echo "Aborting delete cluster request"
     fi

--- a/deploy/cluster_delete.sh
+++ b/deploy/cluster_delete.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Delete cluster
+
+# Relies on the following environment variables:
+#
+# CLUSTER
+# CONFIG
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+exists=$(gcloud container clusters list --filter=$CLUSTER)
+
+if [ $exists ]; then
+    echo "Delete cluster '$CLUSTER' and all it's resources!"
+    read -r -p "Are You Sure? [Y/n] " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+    then
+        gcloud container clusters delete $CLUSTER
+        gcloud container clusters list --filter=$CLUSTER
+    else
+        echo "Aborting delete cluster request"
+    fi
+else
+    echo "Cluster $CLUSTER does not exist!"
+    gcloud container clusters list 
+    exit 1
+fi

--- a/deploy/compiler_deploy_all.sh
+++ b/deploy/compiler_deploy_all.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Deploy all compiler related services
+#
+# This includes: compiler_api (front end), compiler_worker, storage, 
+#      excludes: redis (external service dependency)
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+echo
+echo "Displaying existing deployments and services"
+kubectl get pods
+
+echo
+echo "Deploy Storage Container (temporary)"
+kubectl apply -f yaml/storage-app-svc.yaml
+
+echo
+echo "Deploy compiler worker"
+kubectl apply -f yaml/compiler-worker.yaml
+
+sleep 3
+
+echo
+echo "Deploy compiler api and service"
+kubectl apply -f yaml/compiler-api-svc.yaml
+
+echo
+echo "Displaying updated deployments and services"
+sleep 5
+kubectl get pods
+

--- a/deploy/compiler_deploy_all.sh
+++ b/deploy/compiler_deploy_all.sh
@@ -18,13 +18,27 @@ echo "Displaying existing deployments and services"
 kubectl get pods
 
 echo
+echo "Install configmap"
+./configmap_update.sh
+
+echo
+echo "Persistent Volumes"
+kubectl apply -f yaml/compiler-persistent-volume-claim.yaml
+kubectl apply -f yaml/nfs-persistent-volume-claim.yaml
+kubectl apply -f yaml/nfs-server.yaml
+
+echo
 echo "Deploy Storage Container (temporary)"
 kubectl apply -f yaml/storage-app-svc.yaml
+
+echo "Deploy secrets"
+kubectl apply -f yaml/compiler-secrets.yaml
 
 echo
 echo "Deploy compiler worker"
 kubectl apply -f yaml/compiler-worker.yaml
 
+# Give some time for worker to start
 sleep 3
 
 echo

--- a/deploy/compiler_shutdown_all.sh
+++ b/deploy/compiler_shutdown_all.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Shutdown all compiler related services
+#
+# This includes: compiler_api (front end), compiler_worker, storage, 
+#      excludes: redis (external service dependency)
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+# Don't shut down storage for now - need to detect ip for other configs
+echo "Shutting down compiler API and worker deployment."
+echo
+
+echo "Displaying existing deployments and services"
+kubectl get all
+
+echo "Shutdown compiler worker"
+kubectl delete deployment.apps/compiler-worker
+
+echo "Shutdown compiler api and service"
+kubectl delete deployment.apps/compiler-api
+kubectl delete service/compiler-api
+
+echo "Displaying remaining deployments and services"
+kubectl get all
+

--- a/deploy/config.sh.sample
+++ b/deploy/config.sh.sample
@@ -1,0 +1,20 @@
+# Default settings for development operations in Google Cloud
+
+# Configuration
+export CONFIGMAP="compiler-configmap"
+
+# Top level settings
+export PROJECT="arxiv-compiler-dev"
+export REGION="us-east1"
+export ZONE="us-east1-d"
+
+# Kubernetes Cluster
+export CLUSTER="compiler-cluster"
+export CLUSTER_NODES=2
+export CLUSTER_REGION=$REGION
+
+# Redis
+export REDIS_NAME="compiler-broker"
+export REDIS_ZONE=$ZONE
+export REDIS_REGION=$REGION
+

--- a/deploy/config/compiler-configmap.yaml.sample
+++ b/deploy/config/compiler-configmap.yaml.sample
@@ -11,11 +11,13 @@ data:
   DOCKER_HOST: "tcp://localhost:2375"
   REDIS_ENDPOINT: "10.190.78.203"
   AWS_S3_REGION_NAME: "us-east-1"
-  S3_ENDPOINT: "http://10.92.5.117:4572"
+  S3_ENDPOINT: "http://10.92.7.193:4572"
+  S3_ENDPOINT_new: "http://10.92.5.117:4566"
   S3_VERIFY: "0"
   S3_USE_SSL: ''
   S3_DEBUG: 'true'
-  CONVERTER_DOCKER_IMAGE: "gcr.io/arxiv-compiler-dev/autotex/2020.05"
+  CONVERTER_DOCKER_IMAGE: "626657773168.dkr.ecr.us-east-1.amazonaws.com/arxiv/converter-2020:0.1.0"
+  CONVERTER_DOCKER_IMAGE_WANT: "gcr.io/arxiv-compiler-dev/autotex/2020.05"
   CONVERTER_IMAGE_PULL: "1"
   FILEMANAGER_ENDPOINT: "https://arxiv.org"
   FILEMANAGER_SERVICE_HOST: "arxiv.org"
@@ -37,3 +39,4 @@ data:
   KUBE_TOKEN: "fookubetoken"
   WAIT_FOR_SERVICES: "1"
   WAIT_ON_STARTUP: "5"
+

--- a/deploy/config/compiler-configmap.yaml.sample
+++ b/deploy/config/compiler-configmap.yaml.sample
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: compiler-dev-configmap
+  namespace: default
+data:
+  VERSION: 2021-04-16-V1
+  ANOTE: "Sample Google Cloud Kubernetes compiler configuration"
+  SECRET_KEY: "not secure only use for development"
+  JWT_SECRET: "foosecret"
+  DOCKER_HOST: "tcp://localhost:2375"
+  REDIS_ENDPOINT: "10.190.78.203"
+  AWS_S3_REGION_NAME: "us-east-1"
+  S3_ENDPOINT: "http://10.92.5.117:4572"
+  S3_VERIFY: "0"
+  S3_USE_SSL: ''
+  S3_DEBUG: 'true'
+  CONVERTER_DOCKER_IMAGE: "gcr.io/arxiv-compiler-dev/autotex/2020.05"
+  CONVERTER_IMAGE_PULL: "1"
+  FILEMANAGER_ENDPOINT: "https://arxiv.org"
+  FILEMANAGER_SERVICE_HOST: "arxiv.org"
+  FILEMANAGER_PROTO: "https"
+  FILEMANAGER_SERVICE_PORT: "443"
+  FILEMANAGER_SERVICE_PORT_443_PROTO: "https"
+  FILEMANAGER_PATH: "/"
+  FILEMANAGER_CONTENT_PATH: "/src/{source_id}"
+  FILEMANAGER_STATUS_ENDPOINT: ""
+  FILEMANAGER_VERIFY_CHECKSUM: "0"
+  LOGLEVEL: "10"
+  FLASK_APP: /opt/arxiv/app.py
+  FLASK_DEBUG: "1"
+  DIND_SOURCE_ROOT: "/sources/autotex"
+  WORKER_SOURCE_ROOT: "/sources/autotex"
+  VERBOSE_COMPILE: "1"
+  VAULT_ENABLED: "0"
+  NAMESPACE: "production"
+  KUBE_TOKEN: "fookubetoken"
+  WAIT_FOR_SERVICES: "1"
+  WAIT_ON_STARTUP: "5"

--- a/deploy/configmap_update.sh
+++ b/deploy/configmap_update.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+echo "Map: $CONFIGMAP"
+
+# See what config maps are available
+current=$(kubectl get configmap | grep $CONFIGMAP)
+if [ "$current" ]; then
+  echo "Current configmap:"
+  echo "  $current"
+else
+  echo "Configmap doesn't exist: creating configmap $CONFIGMAP"
+fi
+
+#Install updated configmap
+#kubectl create configmap compiler-configmap --from-env-file compiler-configmap.env 
+
+config_file_path="config/"$CONFIGMAP".yaml"
+
+echo "Updated Configmap: $CONFIGMAP"
+kubectl apply -f $config_file_path
+
+# Show update
+echo "Updating configmap:"
+updated=$(kubectl get configmap | grep $CONFIGMAP)
+echo "  $updated"
+echo
+echo "Would you like to restart compiler API and worker deployments?"
+echo "  You may want to skip restart if you are also deploying"
+echo "  changes to these services."
+read -r -p "Are You Sure? [Y/n] " response
+if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+  echo "Restarted..."
+  kubectl get pods
+  kubectl rollout restart deployment.apps/compiler-api 
+  kubectl rollout restart deployment.apps/compiler-worker
+  sleep 3
+  echo "Restarted..."
+  kubectl get pods
+else
+  echo "Skipping deployment update. Current configmap values may not be "
+  echo "reflected in current deployments."
+fi

--- a/deploy/redis_create.sh
+++ b/deploy/redis_create.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Create Redis cluster
+
+set -e
+
+# Relies on the following environment variales:
+#	PROJECT
+#	REDIS_NAME
+#	REDIS_ZONE
+#	REDIS_REGION
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+# Make sure api is enabled
+gcloud services enable redis.googleapis.com
+
+# Check if Redis is running
+exists=$(gcloud redis instances list  --region=$REDIS_REGION --project=$PROJECT)
+
+if [[ $exists =~ $REDIS_NAME ]]; then
+    echo "ERROR: Redis '$REDIS_NAME' already exists in region. Use or delete existing Redis."
+    echo $exists
+else
+     gcloud redis instances create $REDIS_NAME --tier=basic --redis-version=redis_4_0 --region=$REDIS_REGION --zone=$REDIS_ZONE --project=$PROJECT
+     gcloud redis instances list  --region=$REDIS_REGION --project=$PROJECT
+fi

--- a/deploy/redis_delete.sh
+++ b/deploy/redis_delete.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Delete Redis cluster
+
+# Relies on the following environment variales:
+#       PROJECT
+#       REDIS_NAME
+#       REDIS_ZONE
+#       REDIS_REGION
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+exists=$(gcloud redis instances list  --region=$REDIS_REGION --project=$PROJECT)
+
+if [[ $exists =~ $REDIS_NAME ]]; then
+    echo "Delete Redis '$REDIS_NAME' and all it's resources!"
+    read -r -p "Are You Sure? [Y/n] " response
+    if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+    then
+        gcloud redis instances delete $REDIS_NAME --region=$REDIS_REGION --project=$PROJECT  
+        gcloud redis instances list --region=$REDIS_REGION --project=$PROJECT
+    else
+        echo "Aborting delete cluster request"
+    fi
+else
+    echo "Cluster $REDIS_NAME does not exist!"
+    gcloud container clusters list 
+    exit 1
+fi

--- a/deploy/storage_create.sh
+++ b/deploy/storage_create.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#set -ev
+# Create disks for compilation service
 
 CONFIG="config.sh"
 

--- a/deploy/storage_create.sh
+++ b/deploy/storage_create.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#set -ev
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+echo "Start"
+
+exists=$( gcloud services list | grep file.googleapis.com )
+
+echo "Exists:$exists"
+
+# Enable File storage API
+if [ ! "$exists" ]; then
+    echo "Enabling File Storage API"
+    gcloud services enable file.googleapis.com
+    gcloud services list | grep file.googleapis.com
+else
+    echo "File Storage API is already enabled"
+fi
+
+# Create new filesystem for compilation service
+
+exists=$( gcloud filestore instances list )
+
+if [ ! "$exists" ]; then
+    gcloud filestore instances create compile-data --zone=$ZONE --tier=standard  --file-share=name="compile_data",capacity=1T --network=name="default"
+    gcloud filestore instances list
+else
+    echo "File store exists"
+fi
+
+echo "Create GCP Persistent Disk"
+exists=$( gcloud compute disks list | grep "nfs-compile-service-disk" )
+
+if [ ! "$exists" ]; then
+  echo "Creating new compute disk"
+  gcloud compute disks create --size=10GB --zone=$ZONE nfs-compile-service-disk 
+else 
+  echo "Disk already exists!"
+fi
+
+echo "Done"

--- a/deploy/worker_deploy_or_update.sh
+++ b/deploy/worker_deploy_or_update.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Deploy all compiler releated services
+#
+# This includes: compiler_api (front end), compiler_worker, storage, 
+#      excludes: redis (external service dependency)
+
+CONFIG="config.sh"
+
+if [ -f "$CONFIG" ]; then
+    source $CONFIG
+else
+    echo "Config file '$CONFIG' not found"
+fi
+
+echo "Displaying existing deployments and services"
+kubectl get pods
+
+echo "Deploy compiler worker"
+kubectl apply -f yaml/compiler-worker.yaml
+
+echo "Displaying updated deployments and services"
+kubectl get pods

--- a/deploy/yaml/compiler-api-svc.yaml
+++ b/deploy/yaml/compiler-api-svc.yaml
@@ -1,0 +1,185 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: compiler-api
+  name: compiler-api
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: compiler-api
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: compiler-api
+    spec:
+      containers:
+      - image: gcr.io/arxiv-compiler-dev/arxiv-compiler:v7.13
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: mypvc
+          mountPath: /sources
+        name: arxiv-compiler
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        # My additions to pull in configuration settings.
+        env:
+          # Define the environment settings
+
+          # AWS - S3 and Container Registry - temporary
+          - name: AWS_ACCESS_KEY_ID
+            value: "access_key"
+          - name: AWS_SECRET_ACCESS_KEY
+            value: "secret_access_key"
+          - name: AWS_S3_REGION_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: AWS_S3_REGION_NAME
+
+          # Redis settings
+          - name: REDIS_ENDPOINT_XXX
+            value: "10.190.78.203"
+          - name: REDIS_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: REDIS_ENDPOINT
+
+          # File manager settings
+          - name: FILEMANAGER_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_ENDPOINT
+          - name: FILEMANAGER_VERIFY_CHECKSUM
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_VERIFY_CHECKSUM
+          - name: FILEMANAGER_CONTENT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_CONTENT_PATH
+          - name: FILEMANAGER_STATUS_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_STATUS_ENDPOINT
+
+          # Flask settings
+          - name: FLASK_APP
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FLASK_APP
+          - name: FLASK_DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FLASK_DEBUG
+          - name: JWT_SECRET_XXX
+            value: "foosecret"
+          - name: JWT_SECRET
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: JWT_SECRET
+          - name: LOGLEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: LOGLEVEL
+
+          # S3 Settings
+          - name: S3_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_ENDPOINT
+          - name: S3_VERIFY
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_VERIFY
+          - name: USE_SSL
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_USE_SSL
+          - name: DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_DEBUG
+
+          # General application settings
+          - name: VERBOSE_COMPILE
+            value:
+          - name: VERBOSE_COMPILE
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: VERBOSE_COMPILE
+          - name: WAIT_FOR_SERVICES
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: WAIT_FOR_SERVICES
+          - name: WAIT_ON_STARTUP
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: WAIT_ON_STARTUP
+
+          # Vault is going away
+          - name: VAULT_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: VAULT_ENABLED
+      volumes:
+      - name: mypvc
+        persistentVolumeClaim:
+          claimName: fileserver-claim
+          readOnly: false
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloud.google.com/neg: '{"ingress":true}'
+  finalizers:
+  - service.kubernetes.io/load-balancer-cleanup
+  labels:
+    app: compiler-api
+  name: compiler-api
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - nodePort: 31718
+    port: 80
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: compiler-api
+  sessionAffinity: None
+  type: LoadBalancer

--- a/deploy/yaml/compiler-persistent-volume-claim.yaml
+++ b/deploy/yaml/compiler-persistent-volume-claim.yaml
@@ -1,0 +1,28 @@
+git apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fileserver
+spec:
+  capacity:
+    storage: 1T
+  accessModes:
+  - ReadWriteMany
+  nfs:
+    path: /compile_data
+    server: 10.196.166.178
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fileserver-claim
+spec:
+  # Specify "" as the storageClassName so it matches the PersistentVolume's StorageClass.
+  # A nil storageClassName value uses the default StorageClass. For details, see
+  # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+  accessModes:
+  - ReadWriteMany
+  storageClassName: ""
+  volumeName: fileserver
+  resources:
+    requests:
+      storage: 1T

--- a/deploy/yaml/compiler-secrets.yaml.sample
+++ b/deploy/yaml/compiler-secrets.yaml.sample
@@ -1,0 +1,9 @@
+apiVersion: v1    
+kind: Secret
+metadata:
+  name: compiler-secret
+  namespace: default
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID:  SOMEKEY
+  AWS_SECRET_ACCESS_KEY: SOMEKEY

--- a/deploy/yaml/compiler-worker.yaml
+++ b/deploy/yaml/compiler-worker.yaml
@@ -1,0 +1,243 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: compiler-worker
+  name: compiler-worker
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: compiler-worker
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: compiler-worker
+    spec:
+      imagePullSecrets:
+      - name: gcr-json-key
+      containers:
+      - name: compiler-dind-daemon
+        image: docker:18.09.2-dind
+        volumeMounts:
+        - name: docker-graph-storage
+          mountPath: /var/lib/docker
+        - name: mypvc
+          mountPath: /sources
+        resources:
+          requests:
+            memory: "512Mi"
+          #  cpu: "500m"
+          limits:
+            memory: "1Gi"
+          #  cpu: "1"
+        securityContext:
+          privileged: true
+
+      - name: arxiv-compiler
+        image: gcr.io/arxiv-compiler-dev/arxiv-compiler:v7.13
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: run
+          mountPath: /var/run/celery
+        - name: mypvc
+          mountPath: /sources
+        - name: nfs-volume-1 
+          mountPath: /nfs-data
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        command: ['pipenv', 'run', 'celery', 'worker', '-A', 'compiler.worker.celery_app', '-l', 'INFO', '-E', '--concurrency=2']
+        # Environment settings.
+        env:
+          # Support AWS Containers
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: compiler-secret
+                key: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: compiler-secret
+                key: AWS_SECRET_ACCESS_KEY
+          - name: AWS_S3_REGION_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: AWS_S3_REGION_NAME
+
+          # File manager settings
+          - name: FILEMANAGER_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_ENDPOINT
+          - name: FILEMANAGER_VERIFY_CHECKSUM
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_VERIFY_CHECKSUM
+          - name: FILEMANAGER_CONTENT_PATH
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_CONTENT_PATH
+
+          # Docker settings
+          - name: DOCKER_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: DOCKER_HOST
+          - name: CONVERTER_IMAGE_PULL
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: CONVERTER_IMAGE_PULL
+          - name: DIND_SOURCE_ROOT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: DIND_SOURCE_ROOT
+          - name: WORKER_SOURCE_ROOT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: WORKER_SOURCE_ROOT
+          - name: CONVERTER_DOCKER_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: CONVERTER_DOCKER_IMAGE
+
+          # Redis settings
+          - name: REDIS_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: REDIS_ENDPOINT
+
+          # These Filemanager settings may be defunct - need to check
+          - name: FILEMANAGER_PROTO
+            value: "https"
+          - name: FILEMANAGER_SERVICE_HOST_XXX
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_SERVICE_HOST
+          - name: ANOTE
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: ANOTE
+          - name: FILEMANAGER_SERVICE_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_SERVICE_PORT
+          - name: FILEMANAGER_SERVICE_PORT_443_PROTO
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FILEMANAGER_SERVICE_PORT_443_PROTO
+          - name: FILEMANAGER_STATUS_ENDPOINT
+            value: ""
+
+          # Flask settings
+          - name: FLASK_APP
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FLASK_APP
+          - name: FLASK_DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: FLASK_DEBUG
+          - name: JWT_SECRET
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: JWT_SECRET
+          - name: LOGLEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: LOGLEVEL
+
+          # S3 Settings
+          - name: S3_ENDPOINT
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_ENDPOINT
+          - name: S3_VERIFY
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_VERIFY
+          - name: USE_SSL
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_USE_SSL
+          - name: DEBUG
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: S3_DEBUG
+
+          # General application settings
+          - name: VERBOSE_COMPILE
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: VERBOSE_COMPILE
+          - name: WAIT_FOR_SERVICES
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: WAIT_FOR_SERVICES
+          - name: WAIT_ON_STARTUP
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: WAIT_ON_STARTUP
+
+          # Vault is going away
+          - name: VAULT_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: compiler-dev-configmap
+                key: VAULT_ENABLED
+      volumes:
+      - name: mypvc
+        persistentVolumeClaim:
+          claimName: fileserver-claim
+          readOnly: false
+      - name: nfs-volume-1
+        persistentVolumeClaim:
+          claimName: nfs-pvc
+          readOnly: false
+      - name: docker-graph-storage
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+      - name: sources
+        emptyDir: {}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+

--- a/deploy/yaml/nfs-persistent-volume-claim.yaml
+++ b/deploy/yaml/nfs-persistent-volume-claim.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: nfs-server.default.svc.cluster.local
+    path: "/"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: nfs-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/yaml/nfs-server.yaml
+++ b/deploy/yaml/nfs-server.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: nfs-server
+  template:
+    metadata:
+      labels:
+        role: nfs-server
+    spec:
+      containers:
+      - name: nfs-server
+        image: gcr.io/google_containers/volume-nfs:0.8
+        ports:
+          - name: nfs
+            containerPort: 2049
+          - name: mountd
+            containerPort: 20048
+          - name: rpcbind
+            containerPort: 111
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /data
+            name: nfs-pvc
+      volumes:
+        - name: nfs-pvc
+          gcePersistentDisk:
+            pdName: nfs-compile-service-disk
+            fsType: ext4
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nfs-server
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+    - name: mountd
+      port: 20048
+    - name: rpcbind
+      port: 111
+  selector:
+    role: nfs-server

--- a/deploy/yaml/storage-app-svc.yaml
+++ b/deploy/yaml/storage-app-svc.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aws-localstack
+  name: aws-localstack
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: aws-localstack
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: aws-localstack
+    spec:
+      containers:
+      #- image: atlassianlabs/localstack
+      #- image: localstack/localstack
+      - image: atlassianlabs/localstack
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: nfs-volume-1
+          mountPath: /tmp/localstack
+        name: localstack
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        env:
+          - name: DATA_DIR
+            value: /tmp/localstack/data
+          - name: Version
+            value: AlphaV1.0
+      volumes:
+      - name: nfs-volume-1
+        persistentVolumeClaim:
+          claimName: nfs-pvc
+          readOnly: false
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+# creationTimestamp: "2021-01-24T04:41:05Z"
+  labels:
+    app: aws-localstack
+  name: aws-localstack
+  namespace: default
+#  resourceVersion: "4168525"
+#  selfLink: /api/v1/namespaces/default/services/aws-localstack
+#  uid: 3b09fdf0-5fdf-42fe-b3ef-feab41fe9084
+spec:
+#  clusterIP: 10.3.245.100
+  ports:
+  # was 4572
+  - port: 4572
+    name: storage
+    protocol: TCP
+    targetPort: 4572
+  # was 4568
+  - port: 4568
+    name: kenesis
+    protocol: TCP
+    targetPort: 4568
+  - port: 8080
+    name: dashboard
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: aws-localstack
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
This PR contains scripts and configuration files to deploy a development Compiler Service in Google Cloud Kubernetes. It should be straight forward to deploy this to Phoenix and then add a compile.phoenix.arxiv.org host but I'm waiting to see if the upcoming Submission UI work impacts the Compiler Service before doing so. 

There are scripts to create a Kubernetes cluster and a Redis cluster (outside of Kubernetes). The remaining scripts assume that the Kubernetes and Redis cluster exist.

The development compiler service uses localstack (temporary) so you currently need to set the endpoint in the compiler-configmap.yaml. I plan to automate this shortly and will delete this line when complete.

There are scripts to update specific pieces of the compiler service. The script that brings up everything is _compiler-deploy_all.sh_. This script loads the configmap, requests persistent storage claims, and deploys compiler api, compiler worker, storage service (development/temporary) , and an nfs service (experimental).

There are additional scripts to delete the entire cluster or specific deployments.

I've added a helper script to request compilation (to save you from crafting curl requests) that is currently 'compile_announced.pl'.

    perl ./compile_announced.pl 2012.02375

    Compilation request was ACCEPTED

    URL to check status:

         http://34.75.4.221/2012.02375/Ik1vbiwgMDcgRGVjIDIwMjAgMDE6MDk6MTUgR01UIg%3D%3D/pdf


   There are still things that need to be improved so the compiler service will continue to change during the next sprint where the Submission Ui will be the main focus.